### PR TITLE
adding similarity metrics to edge weights

### DIFF
--- a/nesta_ds_utils/networks/build.py
+++ b/nesta_ds_utils/networks/build.py
@@ -103,7 +103,7 @@ def _cooccurrence_counts(sequences):
     return Counter(chain(*combos))
 
 
-def _frequency_counts(all_tokens: List) -> dict:
+def _node_frequency_counts(all_tokens: List) -> dict:
     """counts frequency of all terms in corpus
 
     Args:
@@ -125,7 +125,7 @@ def _jaccard_similarity(edge_weights: dict, all_tokens: list) -> dict:
     Returns:
         dict: key: pair of tokens, value: jaccard similarity
     """
-    token_frequency = _frequency_counts(all_tokens)
+    token_frequency = _node_frequency_counts(all_tokens)
     jaccard_sims = defaultdict(int)
     for key, val in edge_weights.items():
         jaccard_sims[key] = val / (
@@ -144,7 +144,7 @@ def _association_strength(edge_weights: dict, all_tokens: list) -> dict:
     Returns:
         dict: key: pair of tokens, value: association strength
     """
-    token_frequency = _frequency_counts(all_tokens)
+    token_frequency = _node_frequency_counts(all_tokens)
     association_strengths = defaultdict(int)
     for key, val in edge_weights.items():
         association_strengths[key] = val / (
@@ -163,7 +163,7 @@ def _cosine_sim(edge_weights: dict, all_tokens: list) -> dict:
     Returns:
         dict: key: pair of tokens, value: cosine similarity
     """
-    token_frequency = _frequency_counts(all_tokens)
+    token_frequency = _node_frequency_counts(all_tokens)
     cosine_similarities = defaultdict(int)
     for key, val in edge_weights.items():
         cosine_similarities[key] = val / (
@@ -182,7 +182,7 @@ def _inclusion_index(edge_weights: dict, all_tokens: list) -> dict:
     Returns:
         dict: key: pair of tokens, value: inclusion index
     """
-    token_frequency = _frequency_counts(all_tokens)
+    token_frequency = _node_frequency_counts(all_tokens)
     inclusion_index = defaultdict(int)
     for key, val in edge_weights.items():
         inclusion_index[key] = val / min(

--- a/nesta_ds_utils/networks/build.py
+++ b/nesta_ds_utils/networks/build.py
@@ -119,5 +119,7 @@ def _jaccard_similarity(edge_weights: dict, all_tokens: list) -> dict:
     token_frequency = _frequency_counts(all_tokens)
     jaccard_sims = defaultdict(int)
     for key, val in edge_weights.items():
-        jaccard_sims[key] = val / (token_frequency[key[0]] + token_frequency[key[1]])
+        jaccard_sims[key] = val / (
+            (token_frequency[key[0]] + token_frequency[key[1]]) - val
+        )
     return jaccard_sims

--- a/nesta_ds_utils/networks/build.py
+++ b/nesta_ds_utils/networks/build.py
@@ -34,7 +34,7 @@ def build_coocc(
         use_node_weights (bool, optional): parameter to indicate if node frequency should be added as
             a node attribute.
         edge_attributes (List, optional): parameter to specify any attributes to add to the edges of the network.
-            Available options are 'jaccard_similarity', 'association_strength', 'cosine', or 'inclusion_index'.
+            Available options are 'jaccard', 'association', 'cosine', or 'inclusion'.
             Defaults to []. Functions are based on van Eck and Waltman, 2009.
 
     Returns:
@@ -60,13 +60,13 @@ def build_coocc(
     edge_weights = _cooccurrence_counts(sequences)
 
     # if using similarity metrics as edge attributes, calculate those
-    if "jaccard_similarity" in edge_attributes:
+    if "jaccard" in edge_attributes:
         jaccard_similarity = _jaccard_similarity(edge_weights, all_tokens)
-    if "association_strength" in edge_attributes:
+    if "association" in edge_attributes:
         association_strength = _association_strength(edge_weights, all_tokens)
     if "cosine" in edge_attributes:
         cosine_sim = _cosine_sim(edge_weights, all_tokens)
-    if "inclusion_index" in edge_attributes:
+    if "inclusion" in edge_attributes:
         inclusion_index = _inclusion_index(edge_weights, all_tokens)
 
     # add edges to network
@@ -74,18 +74,18 @@ def build_coocc(
         weight = {"weight": val} if weighted else {}
         jaccard_sim = (
             {"jaccard_similarity": jaccard_similarity[key]}
-            if "jaccard_similarity" in edge_attributes
+            if "jaccard" in edge_attributes
             else {}
         )
         assoc_str = (
             {"association_strength": association_strength[key]}
-            if "association_strength" in edge_attributes
+            if "association" in edge_attributes
             else {}
         )
         co_sim = {"cosine": cosine_sim[key]} if "cosine" in edge_attributes else {}
         inclusion = (
             {"inclusion_index": inclusion_index[key]}
-            if "inclusion_index" in edge_attributes
+            if "inclusion" in edge_attributes
             else {}
         )
 

--- a/nesta_ds_utils/networks/build.py
+++ b/nesta_ds_utils/networks/build.py
@@ -16,7 +16,6 @@ def build_coocc(
     directed: bool = False,
     as_adj: bool = False,
     use_node_weights: bool = False,
-    min_node_frequency: int = 0,
     edge_attributes: List = [],
 ) -> Union[nx.Graph, scipy.sparse._csr.csr_matrix]:
     """generates a co-occurence graph based on pairwise co-occurence of terms.
@@ -34,7 +33,6 @@ def build_coocc(
             rather than a Graph object.
         use_node_weights (bool, optional): parameter to indicate if node frequency should be added as
             a node attribute.
-        min_node_frequency (0, optional): filter nodes with less than the given frequency
         edge_attributes (List, optional): parameter to specify any attributes to add to the edges of the network.
             Available options are 'jaccard_similarity', 'association_strength', 'cosine', or 'inclusion_index'.
             Defaults to []. Functions are based on van Eck and Waltman, 2009.
@@ -51,16 +49,12 @@ def build_coocc(
     # nodes will be all unique tokens in the corpus
     all_tokens = list(chain(*sequences))
     nodes = set(all_tokens)
-    token_frequency = Counter(all_tokens)
-
-    # only add nodes where frequency > min_node_frequency
-    for node, freq in token_frequency:
-        if freq > min_node_frequency:
-            network.add_node(node)
+    network.add_nodes_from(nodes)
 
     # if using node weights, weights will represent frequency in the corpus
     if use_node_weights:
-        nx.set_node_attributes(network, token_frequency, "frequency")
+        node_weights = Counter(all_tokens)
+        nx.set_node_attributes(network, node_weights, "frequency")
 
     # edge weights are all times a pair of tokens have co-occured in the same sequence
     edge_weights = _cooccurrence_counts(sequences)

--- a/nesta_ds_utils/networks/build.py
+++ b/nesta_ds_utils/networks/build.py
@@ -17,7 +17,7 @@ def build_coocc(
     use_node_weights: bool = False,
     edge_attributes: List = [],
 ) -> Union[nx.Graph, scipy.sparse._csr.csr_matrix]:
-    """generates a co-occurence graph based on pairwise co-occurence of terms.
+    """generates a co-occurence graph based on pairwise co-occurence of tokens.
 
     Args:
         sequences (Union[List[list], List[np.array]]):
@@ -104,10 +104,10 @@ def _cooccurrence_counts(sequences):
 
 
 def _node_frequency_counts(all_tokens: List) -> dict:
-    """counts frequency of all terms in corpus
+    """counts frequency of all tokens in corpus
 
     Args:
-        all_tokens (List): list of all terms in corpus
+        all_tokens (List): list of all tokens in corpus
 
     Returns:
         dict: key: token, value: frequency

--- a/tests/networks/test_build.py
+++ b/tests/networks/test_build.py
@@ -62,7 +62,18 @@ def test_directed_network():
     )
 
 
-def test_jaccard_similarity():
+def test_jaccard_exists():
+    """tests that when jaccard similarity is used as an edge attribute it exists"""
+    sequence = [
+        [0, 1, 2, 3, 4],
+        [0, 5, 6, 7, 3, 4],
+    ]
+    network = build_coocc(sequence, edge_attributes=["jaccard"])
+    attr_list = list(list(network.edges(data=True))[0][-1].keys())
+    assert "jaccard_similarity" in attr_list
+
+
+def test_jaccard_similarity_val():
     """tests that when the jaccard similarity is used as an edge attribute it returns the correct value"""
     sequence = [
         [0, 1, 2, 3, 4],
@@ -76,7 +87,18 @@ def test_jaccard_similarity():
         assert attrs[(4, 1)] == 1 / 2
 
 
-def test_association_strength():
+def test_association_strength_exists():
+    """tests that when association strength is used as an edge attribute it exists"""
+    sequence = [
+        [0, 1, 2, 3, 4],
+        [0, 5, 6, 7, 3, 4],
+    ]
+    network = build_coocc(sequence, edge_attributes=["association"])
+    attr_list = list(list(network.edges(data=True))[0][-1].keys())
+    assert "association_strength" in attr_list
+
+
+def test_association_strength_val():
     """tests that when the association strength is used as an edge attribute it returns the correct value"""
     sequence = [
         [0, 1, 2, 3, 4],
@@ -90,7 +112,18 @@ def test_association_strength():
         assert attrs[(4, 1)] == 1 / 2
 
 
-def test_cosine():
+def test_cosine_exists():
+    """tests that when cosine similarity is used as an edge attribute it exists"""
+    sequence = [
+        [0, 1, 2, 3, 4],
+        [0, 5, 6, 7, 3, 4],
+    ]
+    network = build_coocc(sequence, edge_attributes=["cosine"])
+    attr_list = list(list(network.edges(data=True))[0][-1].keys())
+    assert "cosine_similarity" in attr_list
+
+
+def test_cosine_val():
     """tests that when the cosine similarity is used as an edge attribute it returns the correct value"""
     sequence = [
         [0, 1, 2, 3, 4],
@@ -104,7 +137,18 @@ def test_cosine():
         assert attrs[(4, 1)] == 1 / math.sqrt(2)
 
 
-def test_inclusion():
+def test_inclusion_exists():
+    """tests that when the inclusion index is used as an edge attribute it exists"""
+    sequence = [
+        [0, 1, 2, 3, 4],
+        [0, 5, 6, 7, 3, 4],
+    ]
+    network = build_coocc(sequence, edge_attributes=["inclusion"])
+    attr_list = list(list(network.edges(data=True))[0][-1].keys())
+    assert "inclusion_index" in attr_list
+
+
+def test_inclusion_val():
     """tests that when the inclusion index is used as an edge attribute it returns the correct value"""
     sequence = [
         [0, 1, 2, 3, 4],

--- a/tests/networks/test_build.py
+++ b/tests/networks/test_build.py
@@ -2,6 +2,7 @@ import pytest
 from nesta_ds_utils.networks.build import build_coocc
 import numpy as np
 import scipy
+import networkx as nx
 
 
 def test_network_from_nested_lists():
@@ -56,3 +57,14 @@ def test_directed_network():
     assert (
         directed_network.number_of_edges() == 2 * undirected_network.number_of_edges()
     )
+
+
+def test_jaccard_similarity():
+    """tests that when jaccard similarity is used as an edge attribute it returns the correct value"""
+    sequence = [
+        ["I", "went", "to", "the", "party"],
+        ["i", "had", "fun", "at", "the", "party"],
+    ]
+    network = build_coocc(sequence, edge_attributes=["jaccard_similarity"])
+    attrs = nx.get_edge_attributes(network, "jaccard_similarity")
+    assert attrs[("went", "party")] == 1 / 3

--- a/tests/networks/test_build.py
+++ b/tests/networks/test_build.py
@@ -3,6 +3,7 @@ from nesta_ds_utils.networks.build import build_coocc
 import numpy as np
 import scipy
 import networkx as nx
+import math
 
 
 def test_network_from_nested_lists():
@@ -85,3 +86,17 @@ def test_association_strength():
         assert attrs[("went", "party")] == 1 / 2
     else:
         assert attrs[("party", "went")] == 1 / 2
+
+
+def test_cosine():
+    """tests that when the cosine similarity is used as an edge attribute it returns the correct value"""
+    sequence = [
+        ["I", "went", "to", "the", "party"],
+        ["i", "had", "fun", "at", "the", "party"],
+    ]
+    network = build_coocc(sequence, edge_attributes=["cosine"])
+    attrs = nx.get_edge_attributes(network, "cosine")
+    if ("went", "party") in attrs.keys():
+        assert attrs[("went", "party")] == 1 / math.sqrt(2)
+    else:
+        assert attrs[("party", "went")] == 1 / math.sqrt(2)

--- a/tests/networks/test_build.py
+++ b/tests/networks/test_build.py
@@ -68,6 +68,6 @@ def test_jaccard_similarity():
     network = build_coocc(sequence, edge_attributes=["jaccard_similarity"])
     attrs = nx.get_edge_attributes(network, "jaccard_similarity")
     if ("went", "party") in attrs.keys():
-        assert attrs[("went", "party")] == 1 / 3
+        assert attrs[("went", "party")] == 1 / 2
     else:
-        assert attrs[("party", "went")] == 1 / 3
+        assert attrs[("party", "went")] == 1 / 2

--- a/tests/networks/test_build.py
+++ b/tests/networks/test_build.py
@@ -60,7 +60,7 @@ def test_directed_network():
 
 
 def test_jaccard_similarity():
-    """tests that when jaccard similarity is used as an edge attribute it returns the correct value"""
+    """tests that when the jaccard similarity is used as an edge attribute it returns the correct value"""
     sequence = [
         ["I", "went", "to", "the", "party"],
         ["i", "had", "fun", "at", "the", "party"],

--- a/tests/networks/test_build.py
+++ b/tests/networks/test_build.py
@@ -66,7 +66,7 @@ def test_jaccard_similarity():
         ["I", "went", "to", "the", "party"],
         ["i", "had", "fun", "at", "the", "party"],
     ]
-    network = build_coocc(sequence, edge_attributes=["jaccard_similarity"])
+    network = build_coocc(sequence, edge_attributes=["jaccard"])
     attrs = nx.get_edge_attributes(network, "jaccard_similarity")
     if ("went", "party") in attrs.keys():
         assert attrs[("went", "party")] == 1 / 2
@@ -80,7 +80,7 @@ def test_association_strength():
         ["I", "went", "to", "the", "party"],
         ["i", "had", "fun", "at", "the", "party"],
     ]
-    network = build_coocc(sequence, edge_attributes=["association_strength"])
+    network = build_coocc(sequence, edge_attributes=["association"])
     attrs = nx.get_edge_attributes(network, "association_strength")
     if ("went", "party") in attrs.keys():
         assert attrs[("went", "party")] == 1 / 2
@@ -108,7 +108,7 @@ def test_inclusion():
         ["I", "went", "to", "the", "party"],
         ["i", "had", "fun", "at", "the", "party"],
     ]
-    network = build_coocc(sequence, edge_attributes=["inclusion_index"])
+    network = build_coocc(sequence, edge_attributes=["inclusion"])
     attrs = nx.get_edge_attributes(network, "inclusion_index")
     if ("went", "party") in attrs.keys():
         assert attrs[("went", "party")] == 1

--- a/tests/networks/test_build.py
+++ b/tests/networks/test_build.py
@@ -100,3 +100,17 @@ def test_cosine():
         assert attrs[("went", "party")] == 1 / math.sqrt(2)
     else:
         assert attrs[("party", "went")] == 1 / math.sqrt(2)
+
+
+def test_inclusion():
+    """tests that when the inclusion index is used as an edge attribute it returns the correct value"""
+    sequence = [
+        ["I", "went", "to", "the", "party"],
+        ["i", "had", "fun", "at", "the", "party"],
+    ]
+    network = build_coocc(sequence, edge_attributes=["inclusion_index"])
+    attrs = nx.get_edge_attributes(network, "inclusion_index")
+    if ("went", "party") in attrs.keys():
+        assert attrs[("went", "party")] == 1
+    else:
+        assert attrs[("party", "went")] == 1

--- a/tests/networks/test_build.py
+++ b/tests/networks/test_build.py
@@ -67,4 +67,7 @@ def test_jaccard_similarity():
     ]
     network = build_coocc(sequence, edge_attributes=["jaccard_similarity"])
     attrs = nx.get_edge_attributes(network, "jaccard_similarity")
-    assert attrs[("went", "party")] == 1 / 3
+    if ("went", "party") in attrs.keys():
+        assert attrs[("went", "party")] == 1 / 3
+    else:
+        assert attrs[("party", "went")] == 1 / 3

--- a/tests/networks/test_build.py
+++ b/tests/networks/test_build.py
@@ -71,3 +71,17 @@ def test_jaccard_similarity():
         assert attrs[("went", "party")] == 1 / 2
     else:
         assert attrs[("party", "went")] == 1 / 2
+
+
+def test_association_strength():
+    """tests that when the association strength is used as an edge attribute it returns the correct value"""
+    sequence = [
+        ["I", "went", "to", "the", "party"],
+        ["i", "had", "fun", "at", "the", "party"],
+    ]
+    network = build_coocc(sequence, edge_attributes=["association_strength"])
+    attrs = nx.get_edge_attributes(network, "association_strength")
+    if ("went", "party") in attrs.keys():
+        assert attrs[("went", "party")] == 1 / 2
+    else:
+        assert attrs[("party", "went")] == 1 / 2

--- a/tests/networks/test_build.py
+++ b/tests/networks/test_build.py
@@ -12,8 +12,8 @@ def test_network_from_nested_lists():
         ["I", "went", "to", "the", "party"],
         ["i", "had", "fun", "at", "the", "party"],
     ]
-    network = build_coocc(sequence)
-    assert network["the"]["party"]["weight"] == 2
+    network = build_coocc(sequence, edge_attributes=["frequency"])
+    assert network["the"]["party"]["frequency"] == 2
 
 
 def test_network_from_nested_arrays():
@@ -22,8 +22,8 @@ def test_network_from_nested_arrays():
         np.array(["I", "went", "to", "the", "party"]),
         np.array(["i", "had", "fun", "at", "the", "party"]),
     ]
-    network = build_coocc(sequence)
-    assert network["the"]["party"]["weight"] == 2
+    network = build_coocc(sequence, edge_attributes=["frequency"])
+    assert network["the"]["party"]["frequency"] == 2
 
 
 def test_network_as_adjacency_matrix():
@@ -42,7 +42,9 @@ def test_network_node_weight():
         ["I", "went", "to", "the", "party"],
         ["i", "had", "fun", "at", "the", "party"],
     ]
-    network = build_coocc(sequence, use_node_weights=True)
+    network = build_coocc(
+        sequence, use_node_weights=True, edge_attributes=["frequency"]
+    )
     assert network.nodes["the"]["frequency"] == 2
 
 
@@ -95,7 +97,7 @@ def test_cosine():
         ["i", "had", "fun", "at", "the", "party"],
     ]
     network = build_coocc(sequence, edge_attributes=["cosine"])
-    attrs = nx.get_edge_attributes(network, "cosine")
+    attrs = nx.get_edge_attributes(network, "cosine_similarity")
     if ("went", "party") in attrs.keys():
         assert attrs[("went", "party")] == 1 / math.sqrt(2)
     else:

--- a/tests/networks/test_build.py
+++ b/tests/networks/test_build.py
@@ -9,28 +9,28 @@ import math
 def test_network_from_nested_lists():
     """tests that when a list of lists is passed to term_cooccurence_graph it returns the expected edge weights"""
     sequence = [
-        ["I", "went", "to", "the", "party"],
-        ["i", "had", "fun", "at", "the", "party"],
+        [0, 1, 2, 3, 4],
+        [0, 5, 6, 7, 3, 4],
     ]
     network = build_coocc(sequence, edge_attributes=["frequency"])
-    assert network["the"]["party"]["frequency"] == 2
+    assert network[3][4]["frequency"] == 2
 
 
 def test_network_from_nested_arrays():
     """tests that when a list of arrays is passed to term_cooccurence_graph it returns the expected edge weights"""
     sequence = [
-        np.array(["I", "went", "to", "the", "party"]),
-        np.array(["i", "had", "fun", "at", "the", "party"]),
+        np.array([0, 1, 2, 3, 4]),
+        np.array([0, 5, 6, 7, 3, 4]),
     ]
     network = build_coocc(sequence, edge_attributes=["frequency"])
-    assert network["the"]["party"]["frequency"] == 2
+    assert network[3][4]["frequency"] == 2
 
 
 def test_network_as_adjacency_matrix():
     """tests that when as_adj = True the function returns an adjacency matrix"""
     sequence = [
-        ["I", "went", "to", "the", "party"],
-        ["i", "had", "fun", "at", "the", "party"],
+        [0, 1, 2, 3, 4],
+        [0, 5, 6, 7, 3, 4],
     ]
     network, node_list = build_coocc(sequence, as_adj=True)
     assert isinstance(network, scipy.sparse._csr.csr_matrix)
@@ -39,20 +39,20 @@ def test_network_as_adjacency_matrix():
 def test_network_node_weight():
     """tests that when use_node_weights = True the network has the correct node weights"""
     sequence = [
-        ["I", "went", "to", "the", "party"],
-        ["i", "had", "fun", "at", "the", "party"],
+        [0, 1, 2, 3, 4],
+        [0, 5, 6, 7, 3, 4],
     ]
     network = build_coocc(
         sequence, use_node_weights=True, edge_attributes=["frequency"]
     )
-    assert network.nodes["the"]["frequency"] == 2
+    assert network.nodes[3]["frequency"] == 2
 
 
 def test_directed_network():
     """tests that when directed = True the number of edges is double when the network is not directed"""
     sequence = [
-        ["I", "went", "to", "the", "party"],
-        ["i", "had", "fun", "at", "the", "party"],
+        [0, 1, 2, 3, 4],
+        [0, 5, 6, 7, 3, 4],
     ]
     directed_network = build_coocc(sequence, directed=True)
     undirected_network = build_coocc(sequence)
@@ -65,54 +65,54 @@ def test_directed_network():
 def test_jaccard_similarity():
     """tests that when the jaccard similarity is used as an edge attribute it returns the correct value"""
     sequence = [
-        ["I", "went", "to", "the", "party"],
-        ["i", "had", "fun", "at", "the", "party"],
+        [0, 1, 2, 3, 4],
+        [0, 5, 6, 7, 3, 4],
     ]
     network = build_coocc(sequence, edge_attributes=["jaccard"])
     attrs = nx.get_edge_attributes(network, "jaccard_similarity")
-    if ("went", "party") in attrs.keys():
-        assert attrs[("went", "party")] == 1 / 2
+    if (1, 4) in attrs.keys():
+        assert attrs[(1, 4)] == 1 / 2
     else:
-        assert attrs[("party", "went")] == 1 / 2
+        assert attrs[(4, 1)] == 1 / 2
 
 
 def test_association_strength():
     """tests that when the association strength is used as an edge attribute it returns the correct value"""
     sequence = [
-        ["I", "went", "to", "the", "party"],
-        ["i", "had", "fun", "at", "the", "party"],
+        [0, 1, 2, 3, 4],
+        [0, 5, 6, 7, 3, 4],
     ]
     network = build_coocc(sequence, edge_attributes=["association"])
     attrs = nx.get_edge_attributes(network, "association_strength")
-    if ("went", "party") in attrs.keys():
-        assert attrs[("went", "party")] == 1 / 2
+    if (1, 4) in attrs.keys():
+        assert attrs[(1, 4)] == 1 / 2
     else:
-        assert attrs[("party", "went")] == 1 / 2
+        assert attrs[(4, 1)] == 1 / 2
 
 
 def test_cosine():
     """tests that when the cosine similarity is used as an edge attribute it returns the correct value"""
     sequence = [
-        ["I", "went", "to", "the", "party"],
-        ["i", "had", "fun", "at", "the", "party"],
+        [0, 1, 2, 3, 4],
+        [0, 5, 6, 7, 3, 4],
     ]
     network = build_coocc(sequence, edge_attributes=["cosine"])
     attrs = nx.get_edge_attributes(network, "cosine_similarity")
-    if ("went", "party") in attrs.keys():
-        assert attrs[("went", "party")] == 1 / math.sqrt(2)
+    if (1, 4) in attrs.keys():
+        assert attrs[(1, 4)] == 1 / math.sqrt(2)
     else:
-        assert attrs[("party", "went")] == 1 / math.sqrt(2)
+        assert attrs[(4, 1)] == 1 / math.sqrt(2)
 
 
 def test_inclusion():
     """tests that when the inclusion index is used as an edge attribute it returns the correct value"""
     sequence = [
-        ["I", "went", "to", "the", "party"],
-        ["i", "had", "fun", "at", "the", "party"],
+        [0, 1, 2, 3, 4],
+        [0, 5, 6, 7, 3, 4],
     ]
     network = build_coocc(sequence, edge_attributes=["inclusion"])
     attrs = nx.get_edge_attributes(network, "inclusion_index")
-    if ("went", "party") in attrs.keys():
-        assert attrs[("went", "party")] == 1
+    if (1, 4) in attrs.keys():
+        assert attrs[(1, 4)] == 1
     else:
-        assert attrs[("party", "went")] == 1
+        assert attrs[(4, 1)] == 1


### PR DESCRIPTION
# Pull Request Template

This PR closes the issues: #78 

### Description

This adds jaccard similarity, association strength, cosine similarity, and inclusion index as optional edge attributes to the cooccurence network.

### Checklist:

- [X] I have followed [Contributor Guidelines](https://github.com/nestauk/nesta_ds_utils/blob/dev/CONTRIBUTING.md)
- [X] I have updated the documentation to include any new functionality I have added or modified
- [X] I have written unit tests for any new functionality I have added
- [X] I have ran and passed all tests locally with `>> pytest`
- [X] I have checked that all tests ran successfully on the Github after I pushed
