### PR TITLE
Different install requirements

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@ If the feature is approved, open a new Feature Request in the `nesta_ds_utils` r
 2. Clone the repository (we typically use the SSH protocol)
 3. Create and activate a conda environment with python >= 3.8
 4. cd into the top level `nesta_ds_utils` directory
-5. Run `pip install -e ."[dev]"` to install the package with the developer requirements
+5. Run `pip install -e ."[s3,viz,networks,nlp,dev]"` to install the package with the developer requirements
 6. Run `pre-commit install` to setup pre-commit
 7. Create a new branch corresponding to the issue: `git checkout -b [ISSUE NUMBER]_[BRIEF DESCRIPTION]` (ex: 10_fix_docstrings)
 8. Add new functions to corresponding modules, or new modules if feature doesn't fit within existing modules
@@ -53,7 +53,8 @@ If the feature is approved, open a new Feature Request in the `nesta_ds_utils` r
 
 11. Add any new requirements in `setup.cfg` (make sure to include versions):
 
-    - Package requirements should go under `options.install_requires`
+    - General package requirements should go under `options.install_requires`
+    - Usage-specific packages, e.g. `networkx` which will only be used for networks, should go under e.g. `options.extras_require.networks`. This will keep the package lightweight and allow people to only install what they need.
     - Development only requirements should go under `options.extras_require.dev`
     - Testing only requirements should go under `options.extras_require.test`
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@ If the feature is approved, open a new Feature Request in the `nesta_ds_utils` r
 2. Clone the repository (we typically use the SSH protocol)
 3. Create and activate a conda environment with python >= 3.8
 4. cd into the top level `nesta_ds_utils` directory
-5. Run `pip install -e ."[s3,viz,networks,nlp,dev]"` to install the package with the developer requirements
+5. Run `pip install -e ."[dev]"` to install the package with the developer requirements
 6. Run `pre-commit install` to setup pre-commit
 7. Create a new branch corresponding to the issue: `git checkout -b [ISSUE NUMBER]_[BRIEF DESCRIPTION]` (ex: 10_fix_docstrings)
 8. Add new functions to corresponding modules, or new modules if feature doesn't fit within existing modules

--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ The package requires Python 3.8, or higher. To install the basic package functio
 Since this package has functions useful for a wide range of use cases, you can choose which sets of requirements to install with the package. This is handy for not having to download large and potentially dependency-clashing packages unneccessarily.
 
 For example, if you only want to use the functions in the `/networks` folder you can run:
-`pip install git+https://github.com/nestauk/nesta_ds_utils.git[networks]`
+`pip install git+https://github.com/nestauk/nesta_ds_utils.git#egg=nesta_ds_utils"[networks]" `
 
 and if you wanted to use the `/loading_saving` S3 functions and the functions in the `/viz` folder you can run:
-`pip install git+https://github.com/nestauk/nesta_ds_utils.git[s3, viz]`
+`pip install git+https://github.com/nestauk/nesta_ds_utils.git#egg=nesta_ds_utils"[s3,viz]"`
 
 The full set of options to choose from are `[s3, viz, networks, nlp]`.
 

--- a/README.md
+++ b/README.md
@@ -12,10 +12,13 @@ Since this package has functions useful for a wide range of use cases, you can c
 For example, if you only want to use the functions in the `/networks` folder you can run:
 `pip install git+https://github.com/nestauk/nesta_ds_utils.git#egg=nesta_ds_utils"[networks]" `
 
-and if you wanted to use the `/loading_saving` S3 functions and the functions in the `/viz` folder you can run:
+If you wanted to use the `/loading_saving` S3 functions and the functions in the `/viz` folder you can run:
 `pip install git+https://github.com/nestauk/nesta_ds_utils.git#egg=nesta_ds_utils"[s3,viz]"`
 
-The full set of options to choose from are `[s3, viz, networks, nlp]`.
+Alternatively, if you want to have all of the package's functionality you can run:
+`pip install git+https://github.com/nestauk/nesta_ds_utils.git#egg=nesta_ds_utils"[all]"`
+
+The full set of options to choose from are `[s3, viz, networks, nlp, all]`.
 
 ### How to use 📚
 

--- a/README.md
+++ b/README.md
@@ -4,12 +4,22 @@ A Python package with basic utility functions for data science projects at Nesta
 
 ### Installation and requirements ⬇️
 
-The package requires Python 3.8, or higher. To install the package run:  
+The package requires Python 3.8, or higher. To install the basic package functionality run:
 `pip install git+https://github.com/nestauk/nesta_ds_utils.git `
+
+Since this package has functions useful for a wide range of use cases, you can choose which sets of requirements to install with the package. This is handy for not having to download large and potentially dependency-clashing packages unneccessarily.
+
+For example, if you only want to use the functions in the `/networks` folder you can run:
+`pip install git+https://github.com/nestauk/nesta_ds_utils.git[networks]`
+
+and if you wanted to use the `/loading_saving` S3 functions and the functions in the `/viz` folder you can run:
+`pip install git+https://github.com/nestauk/nesta_ds_utils.git[s3, viz]`
+
+The full set of options to choose from are `[s3, viz, networks, nlp]`.
 
 ### How to use 📚
 
-You can import the package, or any spcific modules (ex. `viz`), in Python with:  
+You can import the package, or any specific modules (ex. `viz`), in Python with:
 `import nesta_ds_utils` or `from nesta_ds_utils.viz.altair import saving`
 
 For a full list of the existing modules and functionality check the [Documentation](https://nestauk.github.io/nesta_ds_utils/build/html/index.html). You can also check out a basic [tutorial](https://github.com/nestauk/dap_tutorials/tree/main/nesta_ds_utils_demo).

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,6 +33,13 @@ nlp =
 test =
   pytest==7.1.3
   moto[s3]==4.0.7
+  boto3==1.24.93
+  altair==4.2.0
+  altair-saver==0.5.0
+  matplotlib==3.6.2
+  selenium==4.2.0
+  webdriver_manager==3.8.4
+  networkx==2.8.8
 dev =
   Sphinx==5.2.3
   sphinxcontrib-applehelp==1.0.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,23 +14,22 @@ python_requires = >=3.8
 install_requires =
     numpy==1.23.4
     pandas==1.5.1
-    boto3==1.24.93
-    altair==4.2.0
-    altair_saver==0.5.0
-    selenium==4.2.0
-    webdriver_manager==3.8.4
-    matplotlib==3.6.2
     pyyaml==6.0
-    networkx==2.8.8
-    nltk==3.7
     scipy==1.9.3
     pyarrow==10.0.0
-    networkx==2.8.8
-    nltk==3.7
-    scipy==1.9.3
-    pyarrow==10.0.0
-
 [options.extras_require]
+s3 =
+  boto3==1.24.93
+viz =
+  altair==4.2.0
+  altair-saver==0.5.0
+  matplotlib==3.6.2
+  selenium==4.2.0
+  webdriver_manager==3.8.4
+networks =
+  networkx==2.8.8
+nlp =
+  nltk==3.7
 test =
   pytest==7.1.3
   moto[s3]==4.0.7

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,13 +33,10 @@ nlp =
 test =
   pytest==7.1.3
   moto[s3]==4.0.7
-  boto3==1.24.93
-  altair==4.2.0
-  altair-saver==0.5.0
-  matplotlib==3.6.2
-  selenium==4.2.0
-  webdriver_manager==3.8.4
-  networkx==2.8.8
+  %(s3)s
+  %(viz)s
+  %(networks)s
+  %(nlp)s
 dev =
   Sphinx==5.2.3
   sphinxcontrib-applehelp==1.0.2
@@ -53,6 +50,15 @@ dev =
   pre-commit==2.20.0
   pre-commit-hooks==4.3.0
   black==22.10.0
+  %(s3)s
+  %(viz)s
+  %(networks)s
+  %(nlp)s
+all =
+  %(s3)s
+  %(viz)s
+  %(networks)s
+  %(nlp)s
 
 [options.package_data]
 nesta_ds_utils.viz.themes =


### PR DESCRIPTION
This PR closes the issues: #80 

### Warning

The requirements for any repo this package is used in will need to be updated to specify which parts of the package are needed! I'm also not sure if the way I've done this is as elegant as it could be - so definitely up for suggestions on this.

That being said, as this package hopefully gets bigger and bigger, it will increasingly become a burden to install all the packages needed (imagine downloading spacy and networkx to just read data from S3), so maybe this sort of change is best to do sooner rather than later.

### Description

- Separate out the requirements in setup.cfg
- Update README and CONTRIBUTING.md

### Usage

I tested this with:
```
conda create --name test_package pip python=3.8
conda activate test_package
pip install git+https://github.com/nestauk/nesta_ds_utils.git@80-different-requirements#egg=nesta_ds_utils"[viz]"
```

Then in python, this works:
```

from nesta_ds_utils.viz.altair import saving
import pandas as pd
import altair as alt
fig = alt.Chart(pd.DataFrame()).mark_bar()
saving.save(fig, "test_fig", "tests/", save_png=False, save_html=True)
```
but installing something from the networks functionality doesnt (as expected):
```
from nesta_ds_utils.networks.build import build_coocc
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/elizabethgallagher/miniconda3/envs/test_package/lib/python3.8/site-packages/nesta_ds_utils/networks/build.py", line 7, in <module>
    import networkx as nx
ModuleNotFoundError: No module named 'networkx'
```

If we instead do:
```
pip install git+https://github.com/nestauk/nesta_ds_utils.git@80-different-requirements#egg=nesta_ds_utils"[viz, networks]"
```

then in python we can successfully install both viz and networks functionality
```
from nesta_ds_utils.viz.altair import saving
from nesta_ds_utils.networks.build import build_coocc
```

### Checklist:

- [x] I have followed [Contributor Guidelines](https://github.com/nestauk/nesta_ds_utils/blob/dev/CONTRIBUTING.md)
- [x] I have updated the documentation to include any new functionality I have added or modified
- [ ] I have written unit tests for any new functionality I have added
- [x] I have ran and passed all tests locally with `>> pytest`
- [x] I have checked that all tests ran successfully on the Github after I pushed
