### PR TITLE
refactor(geopandas io): fixes dependency on gpd installation

### DIFF
--- a/nesta_ds_utils/loading_saving/gis_interface.py
+++ b/nesta_ds_utils/loading_saving/gis_interface.py
@@ -1,0 +1,45 @@
+try:
+    from json import loads as load_json
+    from geopandas import GeoDataFrame
+    from io import BytesIO
+    from fnmatch import fnmatch
+
+    _gis_enabled = True
+
+    def _gdf_to_fileobj(df_data: GeoDataFrame, path_to: str, **kwargs) -> BytesIO:
+        """Convert GeoDataFrame into bytes file object.
+
+        Args:
+            df_data (gpd.DataFrame): Dataframe to convert.
+            path_to (str): Saving file name.
+
+        Returns:
+            io.BytesIO: Bytes file object.
+        """
+        buffer = BytesIO()
+        if fnmatch(path_to, "*.geojson"):
+            df_data.to_file(buffer, driver="GeoJSON", **kwargs)
+        else:
+            raise NotImplementedError(
+                "Uploading geodataframe currently supported only for 'geojson'."
+            )
+        buffer.seek(0)
+        return buffer
+
+    def _fileobj_to_gdf(fileobj: BytesIO, path_from: str, **kwargs) -> GeoDataFrame:
+        """Convert bytes file object into geodataframe.
+
+        Args:
+            fileobj (io.BytesIO): Bytes file object.
+            path_from (str): Path of loaded data.
+
+        Returns:
+            gpd.DataFrame: Data as geodataframe.
+        """
+        if fnmatch(path_from, "*.geojson"):
+            return GeoDataFrame.from_features(
+                load_json(fileobj.getvalue().decode())["features"]
+            )
+
+except ImportError:
+    _gis_enabled = False


### PR DESCRIPTION
# Refactor GeoPandas Utils

This PR closes the issues: #91 

### Description

This PR moves geopandas IO to it's own script, `gis_interface.py`. This script attempts import of geopandas dependencies, catching import errors as a deactivated feature flag. `S3.py` will now import this flag and conditionally import utils if import succeeds when `[gis]` feature or `geopandas` is installed.

### Checklist:

- [x] I have followed [Contributor Guidelines](https://github.com/nestauk/nesta_ds_utils/blob/dev/CONTRIBUTING.md)
- [ ] I have updated the documentation to include any new functionality I have added or modified
- [ ] I have written unit tests for any new functionality I have added
- [x] I have ran and passed all tests locally with `>> pytest`
- [x] I have checked that all tests ran successfully on the Github after I pushed
