### PR TITLE
feat: add util function for loading s3 object with encoding

### DIFF
--- a/nesta_ds_utils/loading_saving/S3.py
+++ b/nesta_ds_utils/loading_saving/S3.py
@@ -334,6 +334,20 @@ def _fileobj_to_np_array(fileobj: io.BytesIO, path_from: str, **kwargs) -> np.nd
     return np_array_data
 
 
+def load_with_encoding(bucket_name: str, file_name: str):
+    """
+    Load data from S3 location to allow for encoding.
+    Args:
+        bucket_name: The S3 bucket name
+        file_name: S3 key to load
+    Returns:
+        Loaded data from S3 location
+    """
+    s3 = boto3.client("s3")
+    obj = s3.get_object(Bucket=bucket_name, Key=file_name)
+    return io.BytesIO(obj["Body"].read())
+
+
 def download_obj(
     bucket: str,
     path_from: str,


### PR DESCRIPTION
# Pull Request Template

This PR closes the issues: #100 

### Description

Add `load_with_encoding` to `nesta_ds_utils/loading_saving/S3.py`.

This utility function loads an S3 object body directly to a BytesIO buffer, preserving object encoding.

### Checklist:

- [ ] I have followed [Contributor Guidelines](https://github.com/nestauk/nesta_ds_utils/blob/dev/CONTRIBUTING.md)
- [ ] I have updated the documentation to include any new functionality I have added or modified
- [ ] I have written unit tests for any new functionality I have added
- [x] I have ran and passed all tests locally with `>> pytest`
- [x] I have checked that all tests ran successfully on the Github after I pushed
